### PR TITLE
trigger code linting for PRs to develop

### DIFF
--- a/.github/workflows/code-linting.yml
+++ b/.github/workflows/code-linting.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 # Cancel if a newer run is started
 concurrency:


### PR DESCRIPTION
PRs that will be merged into the develop branch will now trigger the same code-linting workflow used for main. This PR, which is merging into development, serves as its own demonstration, and ironically, has linting issues upon opening.