### PR TITLE
Switch to nf-core's star/align module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -80,6 +80,11 @@
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
+                    "star/align": {
+                        "branch": "master",
+                        "git_sha": "57d75dbac06812c59798a48585032f6e50bb1914",
+                        "installed_by": ["modules"]
+                    },
                     "star/genomegenerate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",

--- a/modules/nf-core/star/align/main.nf
+++ b/modules/nf-core/star/align/main.nf
@@ -5,12 +5,15 @@ process STAR_ALIGN {
     conda "bioconda::star=2.7.10a bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' :
-        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"
+        'biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"
 
     input:
-    tuple val(meta), path(reads)
+    tuple val(meta), path(reads, stageAs: "input*/*")
     path index
     path gtf
+    val star_ignore_sjdbgtf
+    val seq_platform
+    val seq_center
 
     output:
     tuple val(meta), path('*Log.final.out')   , emit: log_final
@@ -24,8 +27,12 @@ process STAR_ALIGN {
     tuple val(meta), path('*Aligned.unsort.out.bam') , optional:true, emit: bam_unsorted
     tuple val(meta), path('*fastq.gz')               , optional:true, emit: fastq
     tuple val(meta), path('*.tab')                   , optional:true, emit: tab
+    tuple val(meta), path('*.SJ.out.tab')            , optional:true, emit: spl_junc_tab
+    tuple val(meta), path('*.ReadsPerGene.out.tab')  , optional:true, emit: read_per_gene_tab
     tuple val(meta), path('*.out.junction')          , optional:true, emit: junction
     tuple val(meta), path('*.out.sam')               , optional:true, emit: sam
+    tuple val(meta), path('*.wig')                   , optional:true, emit: wig
+    tuple val(meta), path('*.bg')                    , optional:true, emit: bedgraph
 
     when:
     task.ext.when == null || task.ext.when
@@ -34,10 +41,12 @@ process STAR_ALIGN {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def reads1 = [], reads2 = []
-    meta.single_end ? reads.each{reads1 << it} : reads.eachWithIndex{ v, ix -> ( ix & 1 ? reads2 : reads1) << v }
-    def attrRG = args.contains("--outSAMattrRGline") ? '' : "--outSAMattrRGline ID:$prefix 'SM:$prefix'"
+    meta.single_end ? [reads].flatten().each{reads1 << it} : reads.eachWithIndex{ v, ix -> ( ix & 1 ? reads2 : reads1) << v }
+    def ignore_gtf      = star_ignore_sjdbgtf ? '' : "--sjdbGTFfile $gtf"
+    def seq_platform    = seq_platform ? "'PL:$seq_platform'" : ""
+    def seq_center      = seq_center ? "'CN:$seq_center'" : ""
+    def attrRG          = args.contains("--outSAMattrRGline") ? "" : "--outSAMattrRGline 'ID:$prefix' $seq_center 'SM:$prefix' $seq_platform"
     def out_sam_type    = (args.contains('--outSAMtype')) ? '' : '--outSAMtype BAM Unsorted'
-    def gtf_param = gtf ? "--sjdbGTFfile $gtf" : ''
     def mv_unsorted_bam = (args.contains('--outSAMtype BAM Unsorted SortedByCoordinate')) ? "mv ${prefix}.Aligned.out.bam ${prefix}.Aligned.unsort.out.bam" : ''
     """
     STAR \\
@@ -46,8 +55,8 @@ process STAR_ALIGN {
         --runThreadN $task.cpus \\
         --outFileNamePrefix $prefix. \\
         $out_sam_type \\
+        $ignore_gtf \\
         $attrRG \\
-        $gtf_param \\
         $args
 
     $mv_unsorted_bam
@@ -79,11 +88,16 @@ process STAR_ALIGN {
     touch ${prefix}.sortedByCoord.out.bam
     touch ${prefix}.toTranscriptome.out.bam
     touch ${prefix}.Aligned.unsort.out.bam
+    touch ${prefix}.Aligned.sortedByCoord.out.bam
     touch ${prefix}.unmapped_1.fastq.gz
     touch ${prefix}.unmapped_2.fastq.gz
     touch ${prefix}.tab
+    touch ${prefix}.SJ.out.tab
+    touch ${prefix}.ReadsPerGene.out.tab
     touch ${prefix}.Chimeric.out.junction
     touch ${prefix}.out.sam
+    touch ${prefix}.Signal.UniqueMultiple.str1.out.wig
+    touch ${prefix}.Signal.UniqueMultiple.str1.out.bg
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/star/align/meta.yml
+++ b/modules/nf-core/star/align/meta.yml
@@ -74,9 +74,16 @@ output:
       type: file
       description: STAR chimeric junction output file (optional)
       pattern: "*.out.junction"
+  - wig:
+      type: file
+      description: STAR output wiggle format file(s) (optional)
+      pattern: "*.wig"
+  - bedgraph:
+      type: file
+      description: STAR output bedGraph format file(s) (optional)
+      pattern: "*.bg"
 
 authors:
   - "@kevinmenden"
   - "@drpatelh"
   - "@praveenraj2018"
-  - "@anoronh4"

--- a/subworkflows/local/align_reads.nf
+++ b/subworkflows/local/align_reads.nf
@@ -1,4 +1,4 @@
-include { STAR_ALIGN       } from '../../modules/local/star/align/main'
+include { STAR_ALIGN       } from '../../modules/nf-core/star/align/main'
 include { UMITOOLS_DEDUP   } from '../../modules/nf-core/umitools/dedup/main'
 include {
     SAMTOOLS_INDEX;
@@ -19,7 +19,10 @@ workflow ALIGN_READS {
     STAR_ALIGN(
         reads,
         star_index,
-        gtf
+        gtf,
+        false,
+        [],
+        []
     )
     ch_versions = ch_versions.mix(STAR_ALIGN.out.versions.first())
 

--- a/subworkflows/local/fusion.nf
+++ b/subworkflows/local/fusion.nf
@@ -1,6 +1,6 @@
-include { STAR_ALIGN as STAR_FOR_ARRIBA     } from '../../modules/local/star/align/main'
+include { STAR_ALIGN as STAR_FOR_ARRIBA     } from '../../modules/nf-core/star/align/main'
 include { ARRIBA                            } from '../../modules/nf-core/arriba/main'
-include { STAR_ALIGN as STAR_FOR_STARFUSION } from '../../modules/local/star/align/main'
+include { STAR_ALIGN as STAR_FOR_STARFUSION } from '../../modules/nf-core/star/align/main'
 include { STARFUSION                        } from '../../modules/local/starfusion/detect/main'
 include { FUSIONCATCHER_DETECT              } from '../../modules/local/fusioncatcher/detect/main'
 include { FUSIONREPORT                      } from '../../modules/local/fusionreport/run/main'
@@ -24,7 +24,10 @@ workflow FUSION {
     STAR_FOR_ARRIBA(
         reads,
         star_index,
-        gtf
+        gtf,
+        false,
+        [],
+        []
     )
     ch_versions = ch_versions.mix(STAR_FOR_ARRIBA.out.versions.first())
 
@@ -44,7 +47,10 @@ workflow FUSION {
         reads,
         // use the star index in the starfusion reference to ensure compatibility
         starfusion_ref.map{ file( it + "/ref_genome.fa.star.idx")},
-        gtf
+        gtf,
+        false,
+        [],
+        []
     )
     ch_versions = ch_versions.mix(STAR_FOR_STARFUSION.out.versions.first())
 

--- a/tests/small_test/test.yml
+++ b/tests/small_test/test.yml
@@ -4,7 +4,7 @@
     - test_profile
   files:
     - path: output/analysis/SAMPLE_PAIRED_END/STAR/SAMPLE_PAIRED_END.Aligned.sortedByCoord.out.bam
-      md5sum: 01678eb7180f5b317048abb4cc06a3b1
+      md5sum: 781acdb8d313482de17a2933e18bb97a
     - path: output/analysis/SAMPLE_PAIRED_END_UMI/STAR/SAMPLE_PAIRED_END_UMI.Aligned.sortedByCoord.out.bam
     - path: output/analysis/SAMPLE_SINGLE_END/STAR/SAMPLE_SINGLE_END.Aligned.sortedByCoord.out.bam
     - path: output/analysis/SAMPLE_SINGLE_END/arriba/SAMPLE_SINGLE_END.fusions.discarded.tsv


### PR DESCRIPTION
Due to the nf-core PRs https://github.com/nf-core/modules/pull/3361 and https://github.com/nf-core/modules/pull/3360, the nf-core version of `star/align` can now handle multiple pairs of input fqs, and also will not fail if a bam is not produced. In this PR, forte's custom implementation of `star/align` is replaced by the latest nf-core `star/align`.