### PR TITLE
fix implementation of label on UMITOOLS_DEDUP module

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -122,7 +122,6 @@ process {
     }
 
     withName: UMITOOLS_DEDUP {
-        label = "process_low"
         ext.prefix = { "${meta.id}.dedup" }
         publishDir = [
             [

--- a/modules.json
+++ b/modules.json
@@ -139,7 +139,8 @@
                     "umitools/dedup": {
                         "branch": "master",
                         "git_sha": "6d9c7e43404e20a97d2f6f88548456afe78282e6",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/umitools/dedup/umitools-dedup.diff"
                     },
                     "umitools/extract": {
                         "branch": "master",

--- a/modules/nf-core/umitools/dedup/main.nf
+++ b/modules/nf-core/umitools/dedup/main.nf
@@ -1,6 +1,6 @@
 process UMITOOLS_DEDUP {
     tag "$meta.id"
-    label "process_single"
+    label "process_low"
 
     conda "bioconda::umi_tools=1.1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
adding `label = "process_low"` or `label = ["process_low"]` in the modules.config file doesn't work for changing the way the resources are allocated for `UMITOOLS_DEDUP`