### PR TITLE
Enhancement/juno resource config

### DIFF
--- a/conf/juno.config
+++ b/conf/juno.config
@@ -14,23 +14,23 @@ process {
     maxRetries     = 3
 
     withLabel:process_single {
-        cpus   = { check_max( 1     * task.attempt, 'cpus'   )                                }
-        memory = { round_memory( check_max( 6.GB * task.cpus, 'memory' )/task.cpus, "down")   }
+        cpus   = { check_max( 1, 'cpus' )                                                     }
+        memory = { round_memory( check_max( 8.GB * task.cpus, 'memory' )/task.cpus, "down")   }
         time   = { check_max( 4.h  * task.attempt, 'time'    )                                }
     }
     withLabel:process_low {
         cpus   = { check_max( 2     * task.attempt, 'cpus'   )                                }
-        memory = { round_memory( check_max( 6.GB * task.cpus, 'memory' )/task.cpus, "down")   }
+        memory = { round_memory( check_max( 8.GB * task.cpus, 'memory' )/task.cpus, "down")   }
         time   = { check_max( 4.h   * task.attempt, 'time'   )                                }
     }
     withLabel:process_medium {
         cpus   = { check_max( 6     * task.attempt, 'cpus'   )                                }
-        memory = { round_memory( check_max( 6.GB * task.cpus, 'memory' )/task.cpus, "down")   }
+        memory = { round_memory( check_max( 8.GB * task.cpus, 'memory' )/task.cpus, "down")   }
         time   = { check_max( 8.h   * task.attempt, 'time'   )                                }
     }
     withLabel:process_high {
         cpus   = { check_max( 12    * task.attempt, 'cpus'   )                                }
-        memory = { round_memory( check_max( 6.GB * task.cpus, 'memory' )/task.cpus, "down")   }
+        memory = { round_memory( check_max( 8.GB * task.cpus, 'memory' )/task.cpus, "down")   }
         time   = { check_max( 16.h  * task.attempt, 'time'   )                                }
     }
     withLabel:process_high_memory {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -123,6 +123,7 @@ process {
 
     withName: UMITOOLS_DEDUP {
         ext.prefix = { "${meta.id}.dedup" }
+        time       = { check_max( 20.h * task.attempt, 'time' ) }
         publishDir = [
             [
                 path: { "${params.outdir}/analysis/${meta.id}/umitools/dedup" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -341,6 +341,7 @@ process {
 
     withName: HTSEQ_COUNT {
         ext.args = { "-s ${meta.single_end || meta.strand == "forward" ? "yes" : meta.strand == "reverse" ? "reverse" : "no" } -r pos" }
+        time     = { check_max( 20.h * task.attempt, 'time' ) }
     }
 
     withName: ARRIBA {


### PR DESCRIPTION
Adjusting resource configurations for juno and individual processes.

Allowing processes in the juno profile with the label `process_single` to have more cpus didn't seem to help so I am changing them back to 1 cpu (which is really what it should be). 

Also changed memory multiplier from 6.GB to 8.GB for several labels on the juno profile. 

I am also giving umitools/dedup and htseq/count more time because we've recently run into `TERM_RUNLIMIT` failures, and retries significantly extend the overall runtime of the pipeline.  