### PR TITLE
Remove mentions of anoronh4 in pipeline/workflow names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# anoronh4/forte: Changelog
+# mskcc/forte: Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v0.0.1 - [date]
 
-Initial release of anoronh4/forte, created with the [nf-core](https://nf-co.re/) template.
+Initial release of mskcc/forte, created with the [nf-core](https://nf-co.re/) template.
 
 ### `Added`
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -1,4 +1,4 @@
-# anoronh4/forte: Citations
+# mskcc/forte: Citations
 
 ## [nf-core](https://pubmed.ncbi.nlm.nih.gov/32055031/)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-**anoronh4/forte** is a best-practice analysis pipeline for bulk RNAseq.
+**mskcc/forte** is a best-practice analysis pipeline for bulk RNAseq.
 
 - **F**unctional
 - **O**bservation of
@@ -29,7 +29,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 3. Download the pipeline and test it on a minimal dataset with a single command:
 
    ```bash
-   nextflow run anoronh4/forte -profile test,singularity --outdir <OUTDIR>
+   nextflow run mskcc/forte -profile test,singularity --outdir <OUTDIR>
    ```
 
    Note that some form of configuration will be needed so that Nextflow knows how to fetch the required software. This is usually done in the form of a config profile (`YOURPROFILE` in the example command above). You can chain multiple config profiles in a comma-separated string.
@@ -42,7 +42,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 4. Start running your own analysis!
 
    ```bash
-   nextflow run anoronh4/forte --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile singularity
+   nextflow run mskcc/forte --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile singularity
    ```
 
    The input file should contain IDs, paths and meta-data pertaining to each sample. The following is a description of each field that can be used. Fields that do not have a default value are required; those that do are not.
@@ -64,7 +64,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 
 ## Credits
 
-anoronh4/forte was originally written by Anne Marie Noronha <noronhaa@mskcc.org>.
+mskcc/forte was originally written by Anne Marie Noronha <noronhaa@mskcc.org>.
 
 We thank the following people for their extensive assistance in the development of this pipeline:
 

--- a/assets/adaptivecard.json
+++ b/assets/adaptivecard.json
@@ -17,7 +17,7 @@
                         "size": "Large",
                         "weight": "Bolder",
                         "color": "<% if (success) { %>Good<% } else { %>Attention<%} %>",
-                        "text": "anoronh4/forte v${version} - ${runName}",
+                        "text": "mskcc/forte v${version} - ${runName}",
                         "wrap": true
                     },
                     {

--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -4,21 +4,21 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <meta name="description" content="anoronh4/forte: RNAseq pipeline">
-  <title>anoronh4/forte Pipeline Report</title>
+  <meta name="description" content="mskcc/forte: RNAseq pipeline">
+  <title>mskcc/forte Pipeline Report</title>
 </head>
 <body>
 <div style="font-family: Helvetica, Arial, sans-serif; padding: 30px; max-width: 800px; margin: 0 auto;">
 
 <img src="cid:nfcorepipelinelogo">
 
-<h1>anoronh4/forte v${version}</h1>
+<h1>mskcc/forte v${version}</h1>
 <h2>Run Name: $runName</h2>
 
 <% if (!success){
     out << """
     <div style="color: #a94442; background-color: #f2dede; border-color: #ebccd1; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
-        <h4 style="margin-top:0; color: inherit;">anoronh4/forte execution completed unsuccessfully!</h4>
+        <h4 style="margin-top:0; color: inherit;">mskcc/forte execution completed unsuccessfully!</h4>
         <p>The exit status of the task that caused the workflow execution to fail was: <code>$exitStatus</code>.</p>
         <p>The full error message was:</p>
         <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0;">${errorReport}</pre>
@@ -27,7 +27,7 @@
 } else {
     out << """
     <div style="color: #3c763d; background-color: #dff0d8; border-color: #d6e9c6; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
-        anoronh4/forte execution completed successfully!
+        mskcc/forte execution completed successfully!
     </div>
     """
 }
@@ -44,8 +44,8 @@
     </tbody>
 </table>
 
-<p>anoronh4/forte</p>
-<p><a href="https://github.com/anoronh4/forte">https://github.com/anoronh4/forte</a></p>
+<p>mskcc/forte</p>
+<p><a href="https://github.com/mskcc/forte">https://github.com/mskcc/forte</a></p>
 
 </div>
 

--- a/assets/email_template.txt
+++ b/assets/email_template.txt
@@ -1,10 +1,10 @@
 Run Name: $runName
 
 <% if (success){
-    out << "## anoronh4/forte execution completed successfully! ##"
+    out << "## mskcc/forte execution completed successfully! ##"
 } else {
     out << """####################################################
-## anoronh4/forte execution completed unsuccessfully! ##
+## mskcc/forte execution completed unsuccessfully! ##
 ####################################################
 The exit status of the task that caused the workflow execution to fail was: $exitStatus.
 The full error message was:
@@ -27,5 +27,5 @@ Pipeline Configuration:
 <% out << summary.collect{ k,v -> " - $k: $v" }.join("\n") %>
 
 --
-anoronh4/forte
-https://github.com/anoronh4/forte
+mskcc/forte
+https://github.com/mskcc/forte

--- a/assets/methods_description_template.yml
+++ b/assets/methods_description_template.yml
@@ -1,11 +1,11 @@
 id: "anoronh4-forte-methods-description"
 description: "Suggested text and references to use when describing pipeline usage within the methods section of a publication."
-section_name: "anoronh4/forte Methods Description"
-section_href: "https://github.com/anoronh4/forte"
+section_name: "mskcc/forte Methods Description"
+section_href: "https://github.com/mskcc/forte"
 plot_type: "html"
 data: |
   <h4>Methods</h4>
-  <p>Data was processed using anoronh4/forte v${workflow.manifest.version} ${doi_text}.</p>
+  <p>Data was processed using mskcc/forte v${workflow.manifest.version} ${doi_text}.</p>
   <p>The pipeline was executed with Nextflow v${workflow.nextflow.version} (<a href="https://doi.org/10.1038/nbt.3820">Di Tommaso <em>et al.</em>, 2017</a>) with the following command:</p>
   <pre><code>${workflow.commandLine}</code></pre>
   <h4>References</h4>

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/anoronh4/forte/master/assets/schema_input.json",
-    "title": "anoronh4/forte pipeline - params.input schema",
+    "$id": "https://raw.githubusercontent.com/mskcc/forte/master/assets/schema_input.json",
+    "title": "mskcc/forte pipeline - params.input schema",
     "description": "Schema for the file provided with params.input",
     "type": "array",
     "items": {

--- a/conf/base.config
+++ b/conf/base.config
@@ -1,6 +1,6 @@
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    anoronh4/forte Nextflow base config file
+    mskcc/forte Nextflow base config file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     A 'blank slate' config file, appropriate for general use on most high performance
     compute environments. Assumes that all software is installed and available on

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -27,7 +27,7 @@ process {
         ]
     }
 
-    withName: 'ANORONH4_FORTE:FORTE:MULTIQC' {
+    withName: 'MSKCC_FORTE:FORTE:MULTIQC' {
         publishDir = [
             path: { "${report.folder}/report" },
             mode: params.publish_dir_mode,

--- a/conf/test.config
+++ b/conf/test.config
@@ -5,7 +5,7 @@
     Defines input files and everything required to run a fast and simple pipeline test.
 
     Use as follows:
-        nextflow run anoronh4/forte -profile test,<docker/singularity> --outdir <OUTDIR>
+        nextflow run mskcc/forte -profile test,<docker/singularity> --outdir <OUTDIR>
 
 ----------------------------------------------------------------------------------------
 */

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -5,7 +5,7 @@
     Defines input files and everything required to run a full size pipeline test.
 
     Use as follows:
-        nextflow run anoronh4/forte -profile test_full,<docker/singularity> --outdir <OUTDIR>
+        nextflow run mskcc/forte -profile test_full,<docker/singularity> --outdir <OUTDIR>
 
 ----------------------------------------------------------------------------------------
 */

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# anoronh4/forte: Documentation
+# mskcc/forte: Documentation
 
-The anoronh4/forte documentation is split into the following pages:
+The mskcc/forte documentation is split into the following pages:
 
 - [Usage](usage.md)
   - An overview of how the pipeline works, how to run it and a description of all of the different command-line flags.

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,4 +1,4 @@
-# anoronh4/forte: Output
+# mskcc/forte: Output
 
 ## Introduction
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# anoronh4/forte: Usage
+# mskcc/forte: Usage
 
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 
@@ -61,7 +61,7 @@ the following is a description of each field that can be used. Fields that do no
 The typical command for running the pipeline is as follows:
 
 ```bash
-nextflow run anoronh4/forte --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile singularity
+nextflow run mskcc/forte --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile singularity
 ```
 
 This will launch the pipeline with the `singularity` configuration profile. See below for more information about profiles.
@@ -80,7 +80,7 @@ work                # Directory containing the nextflow working files
 When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:
 
 ```bash
-nextflow pull anoronh4/forte
+nextflow pull mskcc/forte
 ```
 
 ### Fusion-report annotation
@@ -109,7 +109,7 @@ Forte performs QC analysis on targeted assays using Picard's `CollectHsMetrics` 
 
 It is a good idea to specify a pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
 
-First, go to the [anoronh4/forte releases page](https://github.com/anoronh4/forte/releases) and find the latest version number - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.1`.
+First, go to the [mskcc/forte releases page](https://github.com/mskcc/forte/releases) and find the latest version number - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.1`.
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future.
 

--- a/lib/WorkflowForte.groovy
+++ b/lib/WorkflowForte.groovy
@@ -1,5 +1,5 @@
 //
-// This file holds several functions specific to the workflow/forte.nf in the anoronh4/forte pipeline
+// This file holds several functions specific to the workflow/forte.nf in the mskcc/forte pipeline
 //
 
 import groovy.text.SimpleTemplateEngine

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -1,5 +1,5 @@
 //
-// This file holds several functions specific to the main.nf workflow in the anoronh4/forte pipeline
+// This file holds several functions specific to the main.nf workflow in the mskcc/forte pipeline
 //
 
 class WorkflowMain {

--- a/main.nf
+++ b/main.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    anoronh4/forte
+    mskcc/forte
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Github : https://github.com/anoronh4/forte
+    Github : https://github.com/mskcc/forte
 ----------------------------------------------------------------------------------------
 */
 
@@ -35,9 +35,9 @@ WorkflowMain.initialise(workflow, params, log)
 include { FORTE } from './workflows/forte'
 
 //
-// WORKFLOW: Run main anoronh4/forte analysis pipeline
+// WORKFLOW: Run main mskcc/forte analysis pipeline
 //
-workflow ANORONH4_FORTE {
+workflow MSKCC_FORTE {
     FORTE ()
 }
 
@@ -52,7 +52,7 @@ workflow ANORONH4_FORTE {
 // See: https://github.com/nf-core/rnaseq/issues/619
 //
 workflow {
-    ANORONH4_FORTE ()
+    MSKCC_FORTE ()
 }
 
 /*

--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,6 @@
 {
-    "name": "anoronh4/forte",
-    "homePage": "https://github.com/anoronh4/forte",
+    "name": "mskcc/forte",
+    "homePage": "https://github.com/mskcc/forte",
     "repos": {
         "https://github.com/nf-core/modules.git": {
             "modules": {

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -13,7 +13,7 @@ process SAMPLESHEET_CHECK {
     path '*.csv'       , emit: csv
     path "versions.yml", emit: versions
 
-    script: // This script is bundled with the pipeline, in anoronh4/forte/bin/
+    script: // This script is bundled with the pipeline, in mskcc/forte/bin/
     """
     check_samplesheet.py \\
         $samplesheet \\

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/anoronh4/forte/master/nextflow_schema.json",
-    "title": "anoronh4/forte pipeline parameters",
+    "$id": "https://raw.githubusercontent.com/mskcc/forte/master/nextflow_schema.json",
+    "title": "mskcc/forte pipeline parameters",
     "description": "RNAseq pipeline",
     "type": "object",
     "definitions": {


### PR DESCRIPTION
Because the pipeline code used to be hosted at github.com/anoronh4/forte and was created with the name anoronh4/forte, there are many mentions of the original name in the URL links and documentation and objects within the code. Now that the new home of the pipeline is https://github.com/mskcc/forte, those need to be replaced with mskcc/forte or in some cases MSKCC_FORTE. 