### PR TITLE
Add timeout for github action

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-20.04
-    timeout-minutes: 2
+    timeout-minutes: 45
 
     name: ${{ matrix.tags }} ${{ matrix.profile }}
     strategy:


### PR DESCRIPTION
Add timeout limit of 45 minutes to github action workflow that runs the pytest, in order to cancel jobs that are hanging or having other issues, and prevent eating up github action quota. 