### PR TITLE
lower resource requirement for htseq/count and starfusion

### DIFF
--- a/modules/local/htseq/count/main.nf
+++ b/modules/local/htseq/count/main.nf
@@ -1,6 +1,6 @@
 process HTSEQ_COUNT {
     tag "$meta.id"
-    label 'process_medium'
+    label 'process_low'
 
     conda "bioconda::htseq=2.0.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/starfusion/detect/main.nf
+++ b/modules/local/starfusion/detect/main.nf
@@ -1,6 +1,6 @@
 process STARFUSION {
     tag "$meta.id"
-    label 'process_high'
+    label 'process_low'
 
     conda "bioconda::dfam=3.3 bioconda::hmmer=3.3.2 bioconda::star-fusion=1.10.0 bioconda::trinity=date.2011_11_2 bioconda::samtools=1.9 bioconda::star=2.7.8a"
     container "docker.io/trinityctat/starfusion:1.10.1"


### PR DESCRIPTION
In an analysis of their performance i found that these processes had unnecessarily high memory. htseq/count also was delayed in getting scheduled to the cluster, possibly due to the high resource allocation. Hopefully jobs for these two processes will take less time to get scheduled. 