### PR TITLE
publish QC results to non-overlapping locations

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -341,6 +341,27 @@ process {
 
     withName: PICARD_COLLECTRNASEQMETRICS {
         ext.args = { "--STRAND_SPECIFICITY ${meta.single_end || meta.strand == "forward" ? "FIRST_READ_TRANSCRIPTION_STRAND" : meta.strand == "reverse" ? "SECOND_READ_TRANSCRIPTION_STRAND" : "NONE" }" }
+        publishDir = [
+            path: { "${params.outdir}/${meta ? "analysis/" + meta.sample + "/" : "" }${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}/${task.process.tokenize(':')[-2].tokenize('_')[1].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: PICARD_COLLECTHSMETRICS {
+        publishDir = [
+            path: { "${params.outdir}/${meta ? "analysis/" + meta.sample + "/" : "" }${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}/${task.process.tokenize(':')[-2].tokenize('_')[1].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'RSEQC_.*' {
+        publishDir = [
+            path: { "${params.outdir}/${meta ? "analysis/" + meta.sample + "/" : "" }${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}/${task.process.tokenize(':')[-3].tokenize('_')[1].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
 
     withName: HTSEQ_COUNT {


### PR DESCRIPTION
separated publishDir locations for '.*:QC_DUP:.*' and '.*:QC_DEDUP:.*' results, so they do not overwrite each other.

This PR should close #56