### PR TITLE
Update/mqc container

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -57,7 +57,7 @@
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "ee80d14721e76e2e079103b8dcd5d57129e584ba",
+                        "git_sha": "a6e11ac655e744f7ebc724be669dd568ffdc0e80",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/multiqc/multiqc.diff"
                     },

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -1,10 +1,10 @@
 process MULTIQC {
     label 'process_single'
 
-    conda "bioconda::multiqc=1.14"
+    conda "bioconda::multiqc=1.15"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.14--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.15--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.15--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(multiqc_files, stageAs: "?/*")

--- a/modules/nf-core/multiqc/meta.yml
+++ b/modules/nf-core/multiqc/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: MultiQC
 description: Aggregate results from bioinformatics analyses across many samples into a single report
 keywords:
@@ -14,11 +15,6 @@ tools:
       licence: ["GPL-3.0-or-later"]
 
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing meta information
-        e.g. [ id:'test' ]
   - multiqc_files:
       type: file
       description: |
@@ -42,7 +38,7 @@ output:
       description: MultiQC report file
       pattern: "multiqc_report.html"
   - data:
-      type: dir
+      type: directory
       description: MultiQC data dir
       pattern: "multiqc_data"
   - plots:

--- a/modules/nf-core/multiqc/multiqc.diff
+++ b/modules/nf-core/multiqc/multiqc.diff
@@ -1,24 +1,42 @@
 Changes in module 'nf-core/multiqc'
---- modules/nf-core/multiqc/meta.yml
-+++ modules/nf-core/multiqc/meta.yml
-@@ -14,6 +14,12 @@
-       licence: ["GPL-3.0-or-later"]
- 
- input:
-+  - meta:
-+      type: 
-+      type: map
-+      description: |
-+        Groovy Map containing meta information
-+        e.g. [ id:'test' ]
-   - multiqc_files:
-       type: file
-       description: |
+--- /dev/null
++++ modules/nf-core/multiqc/stash_multiqc.diff
+@@ -0,0 +1,30 @@
++Changes in module 'nf-core/multiqc'
++--- modules/nf-core/multiqc/meta.yml
+++++ modules/nf-core/multiqc/meta.yml
++@@ -14,6 +14,12 @@
++       licence: ["GPL-3.0-or-later"]
++ 
++ input:
+++  - meta:
+++      type: 
+++      type: map
+++      description: |
+++        Groovy Map containing meta information
+++        e.g. [ id:'test' ]
++   - multiqc_files:
++       type: file
++       description: |
++
++--- modules/nf-core/multiqc/main.nf
+++++ modules/nf-core/multiqc/main.nf
++@@ -7,7 +7,7 @@
++         'quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0' }"
++ 
++     input:
++-    path  multiqc_files, stageAs: "?/*"
+++    tuple val(meta), path(multiqc_files, stageAs: "?/*")
++     path(multiqc_config)
++     path(extra_multiqc_config)
++     path(multiqc_logo)
++
++************************************************************
 
 --- modules/nf-core/multiqc/main.nf
 +++ modules/nf-core/multiqc/main.nf
 @@ -7,7 +7,7 @@
-         'quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0' }"
+         'biocontainers/multiqc:1.15--pyhdfd78af_0' }"
  
      input:
 -    path  multiqc_files, stageAs: "?/*"

--- a/subworkflows/local/align_reads.nf
+++ b/subworkflows/local/align_reads.nf
@@ -65,5 +65,6 @@ workflow ALIGN_READS {
     bai_dedup       = SAMTOOLS_INDEX_DEDUP.out.bai
     bai_withdup     = SAMTOOLS_INDEX.out.bai
     star_log_final  = STAR_ALIGN.out.log_final
+    umitools_dedup_log = UMITOOLS_DEDUP.out.log
     ch_versions     = ch_versions
 }

--- a/workflows/forte.nf
+++ b/workflows/forte.nf
@@ -144,7 +144,7 @@ workflow FORTE {
         QUANTIFICATION.out.kallisto_log
             .filter{meta, log ->
                 meta.has_umi && params.dedup_umi_for_kallisto
-            }.mix(ALIGN_READS.umitools_dedup_log)
+            }.mix(ALIGN_READS.out.umitools_dedup_log)
             .mix(
                 QUANTIFICATION.out.htseq_counts
                     .filter{ meta, counts -> meta.has_umi }

--- a/workflows/forte.nf
+++ b/workflows/forte.nf
@@ -144,7 +144,11 @@ workflow FORTE {
         QUANTIFICATION.out.kallisto_log
             .filter{meta, log ->
                 meta.has_umi && params.dedup_umi_for_kallisto
-            },
+            }.mix(ALIGN_READS.umitools_dedup_log)
+            .mix(
+                QUANTIFICATION.out.htseq_counts
+                    .filter{ meta, counts -> meta.has_umi }
+            ),
         PREPARE_REFERENCES.out.refflat,
         PREPARE_REFERENCES.out.rrna_interval_list,
         PREPARE_REFERENCES.out.rseqc_bed,
@@ -158,8 +162,10 @@ workflow FORTE {
         ALIGN_READS.out.bam_withdup,
         ALIGN_READS.out.bai_withdup,
         PREPROCESS_READS.out.fastp_json
-            .mix(QUANTIFICATION.out.htseq_counts)
-            .mix(ALIGN_READS.out.star_log_final)
+            .mix(
+                QUANTIFICATION.out.htseq_counts
+                    .filter{ meta, counts -> ! meta.has_umi }
+            ).mix(ALIGN_READS.out.star_log_final)
             .mix(
                 QUANTIFICATION.out.kallisto_log
                     .filter{meta, log ->


### PR DESCRIPTION
Multiqc has a new release (1.15) which was updated in the nf-core module repository. As a result, the module is being updated in the pipeline. Since the new release includes the commit 57bd6aa, which fixes a bug in parsing umitools dedup info (https://github.com/ewels/MultiQC/issues/1845) code has been added to display UMITOOLS_DEDUP in the multiqc report.