### PR TITLE
fix docker registry issues

### DIFF
--- a/modules/local/agfusion/batch/main.nf
+++ b/modules/local/agfusion/batch/main.nf
@@ -5,8 +5,8 @@ process AGFUSION_BATCH {
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda 'bioconda::agfusion=1.252'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'cmopipeline/agfusion:0.0.6' :
-        'cmopipeline/agfusion:0.0.6' }"
+        'docker://cmopipeline/agfusion:0.0.6' :
+        'docker://cmopipeline/agfusion:0.0.6' }"
 
     input:
     tuple val(meta), path(fusions)

--- a/modules/local/agfusion/download/main.nf
+++ b/modules/local/agfusion/download/main.nf
@@ -4,8 +4,8 @@ process AGFUSION_DOWNLOAD {
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda 'bioconda::agfusion=1.252'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'cmopipeline/agfusion:0.0.6' :
-        'cmopipeline/agfusion:0.0.6' }"
+        'docker://cmopipeline/agfusion:0.0.6' :
+        'docker://cmopipeline/agfusion:0.0.6' }"
 
     input:
     val(ensembl_release)

--- a/modules/local/metafusion/main.nf
+++ b/modules/local/metafusion/main.nf
@@ -3,8 +3,8 @@ process METAFUSION {
     label "process_low"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'cmopipeline/metafusion:0.0.6' :
-        'cmopipeline/metafusion:0.0.6' }"
+        'docker://cmopipeline/metafusion:0.0.6' :
+        'docker://cmopipeline/metafusion:0.0.6' }"
 
     input:
     tuple val(meta), path(cff)

--- a/modules/local/oncokb/fusionannotator/main.nf
+++ b/modules/local/oncokb/fusionannotator/main.nf
@@ -5,8 +5,8 @@ process ONCOKB_FUSIONANNOTATOR {
     // Note: 2.7X indices incompatible with AWS iGenomes.
     //conda "shahcompbio::oncokb-annotator=2.3.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'cmopipeline/oncokb-annotator:0.0.1' :
-        'cmopipeline/oncokb-annotator:0.0.1' }"
+        'docker://cmopipeline/oncokb-annotator:0.0.1' :
+        'docker://cmopipeline/oncokb-annotator:0.0.1' }"
 
     input:
     tuple val(meta), path(cff)


### PR DESCRIPTION
docker registry for some of the local modules is broken due to apptainer registry definition, which was updated in #94 when the pipeline template was synchronized.