### PR TITLE
allow dynamic increase of memory for process_single label

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Install editorconfig-checker
         run: npm install -g editorconfig-checker

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
 
       - name: Install editorconfig-checker
         run: npm install -g editorconfig-checker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#125](https://github.com/mskcc/forte/pull/125) - update upload-artifact version because the version previously in use (v2) is deprecated.
 
+- [#127](https://github.com/mskcc/forte/pull/127) - allow dynamic increase of memory for process_single label
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/conf/juno.config
+++ b/conf/juno.config
@@ -15,7 +15,7 @@ process {
 
     withLabel:process_single {
         cpus   = { check_max( 1, 'cpus' )                                                     }
-        memory = { round_memory( check_max( 8.GB * task.cpus, 'memory' )/task.cpus, "down")   }
+	memory = { check_max( 8.GB * task.attempt, 'memory' )                                    }
         time   = { check_max( 4.h  * task.attempt, 'time'    )                                }
     }
     withLabel:process_low {

--- a/conf/juno.config
+++ b/conf/juno.config
@@ -15,7 +15,7 @@ process {
 
     withLabel:process_single {
         cpus   = { check_max( 1, 'cpus' )                                                     }
-	memory = { check_max( 8.GB * task.attempt, 'memory' )                                    }
+        memory = { check_max( 8.GB * task.attempt, 'memory' )                                    }
         time   = { check_max( 4.h  * task.attempt, 'time'    )                                }
     }
     withLabel:process_low {


### PR DESCRIPTION
memory for processes with the `'process_single'` label were written like so: 
```
cpus   = { check_max( 1, 'cpus' )
memory = { round_memory( check_max( 8.GB * task.cpus, 'memory' )/task.cpus, "down")   }
```
so cpus was always 1 and memory was always 8. This pr fixes it so that the memory is dynamically increased with each retry. 

<!--
# mskcc/forte pull request

Many thanks for contributing to mskcc/forte!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the develop branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/mskcc/forte/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/mskcc/forte/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the mskcc/forte _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
