### PR TITLE
add split reads 2 to arriba split_cnt in cff, fix logic for FC split …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#124](https://github.com/mskcc/forte/pull/124) - ensure genebed file as 0based start site
 
 - [#127](https://github.com/mskcc/forte/pull/127) - allow dynamic increase of memory for process_single label
+  
+- [#132](https://github.com/mskcc/forte/pull/132) - fix generate cff split/span logic for fusioncatcher and arriba
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#124](https://github.com/mskcc/forte/pull/124) - ensure genebed file as 0based start site
 
 - [#127](https://github.com/mskcc/forte/pull/127) - allow dynamic increase of memory for process_single label
-  
+
 - [#132](https://github.com/mskcc/forte/pull/132) - fix generate cff split/span logic for fusioncatcher and arriba
 
 ### `Dependencies`

--- a/bin/make_cff_from_forte.R
+++ b/bin/make_cff_from_forte.R
@@ -54,7 +54,7 @@ make_arriba <- function(sample_file) {
         str_split_fixed(sample_file$`strand2(gene/fusion)`, "/", 2)[, 1]
     df$tool <- "arriba"
     df$split_cnt <- apply(sample_file[,c("split_reads1","split_reads2")], 1, sum,na.rm=TRUE)
-    df$split_cnt <- 
+    df$split_cnt <-
         ifelse( !is.na(df$split_cnt),
             df$split_cnt,
             -1)

--- a/bin/make_cff_from_forte.R
+++ b/bin/make_cff_from_forte.R
@@ -53,9 +53,10 @@ make_arriba <- function(sample_file) {
     df$strand2 <-
         str_split_fixed(sample_file$`strand2(gene/fusion)`, "/", 2)[, 1]
     df$tool <- "arriba"
-    df$split_cnt <-
-        ifelse(!is.na(sample_file$split_reads1),
-            sample_file$split_reads1,
+    df$split_cnt <- apply(sample_file[,c("split_reads1","split_reads2")], 1, sum,na.rm=TRUE)
+    df$split_cnt <- 
+        ifelse( !is.na(df$split_cnt), 
+            df$split_cnt, 
             -1)
     df$span_cnt <-
         ifelse(!is.na(sample_file$discordant_mates),
@@ -85,12 +86,7 @@ make_fusioncatcher <- function(sample_file) {
     df$strand2 <-
         str_split_fixed(sample_file[, "Fusion_point_for_gene_2(3end_fusion_partner)"], ":", 3)[, 3]
     df$tool <- "fusioncatcher"
-    df$split_cnt <-
-        ifelse(
-            !is.na(sample_file$Spanning_unique_reads),
-            sample_file$Spanning_unique_reads,
-            -1
-        )
+    df$split_cnt <- -1
     df$span_cnt <-
         ifelse(!is.na(sample_file$Spanning_pairs),
             sample_file$Spanning_pairs,

--- a/bin/make_cff_from_forte.R
+++ b/bin/make_cff_from_forte.R
@@ -55,8 +55,8 @@ make_arriba <- function(sample_file) {
     df$tool <- "arriba"
     df$split_cnt <- apply(sample_file[,c("split_reads1","split_reads2")], 1, sum,na.rm=TRUE)
     df$split_cnt <- 
-        ifelse( !is.na(df$split_cnt), 
-            df$split_cnt, 
+        ifelse( !is.na(df$split_cnt),
+            df$split_cnt,
             -1)
     df$span_cnt <-
         ifelse(!is.na(sample_file$discordant_mates),


### PR DESCRIPTION
- [x] Edit generation of CFF for arriba and fusioncatcher to improve logic. Split reads for arriba should be adding split_reads1 and split_reads2, while fusioncatcher does not separate split and spanning reads. For fusion catcher set -1 (NULL value for metafusion) for split reads, and set spanning reads value to Spanning_pairs. This will not effect the format of make_cff or metafusion. This will not alter the way metafusion functions. 
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
