### PR TITLE
Downgrade nf-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#142](https://github.com/mskcc/forte/pull/142) - Template update from nf-core/tools v3.2.0
 
+- [#149](https://github.com/mskcc/forte/pull/149) - Temporary downgrade of nf-schema to 2.2.0 to allow tests to complete
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/nextflow.config
+++ b/nextflow.config
@@ -287,7 +287,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.3.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.2.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
nf-schema is running into problems with latest versions of nextflow. this is preventing all CI nf-tests from completing. the temporary recommendation in the nf-core slack is to downgrade nf-schema to 2.2.0 until they have a patch. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/mskcc/forte/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the mskcc/forte _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
