### PR TITLE
exclude fusions which have NAfrom AGFusion clinical run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#151](https://github.com/mskcc/forte/pull/151) - Replace samtools bam2fq with gatk4 samtofastq for better handling of paired reads in a position sorted bam
 
+- [#159](https://github.com/mskcc/forte/pull/159) - Exclude any fusion with NA as one of the genes from agfusion clinical run
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/modules/local/add_flags/main.nf
+++ b/modules/local/add_flags/main.nf
@@ -33,7 +33,7 @@ process ADD_FLAG {
     cat *_metafusion_cluster.unfiltered.cff \\
         | awk 'FNR <= 1' > header.txt
     cat *_metafusion_cluster.unfiltered.cff \\
-        | grep -iFwf $clinical_genes > tmp_clinicalgenes.txt
+        | grep -iFwf $clinical_genes | awk '\$20 != "NA" && \$22 != "NA"' > tmp_clinicalgenes.txt
     cat header.txt tmp_clinicalgenes.txt > ${sample}_metafusion_cluster.unfiltered.clinical.cff
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/add_flags/main.nf
+++ b/modules/local/add_flags/main.nf
@@ -33,7 +33,7 @@ process ADD_FLAG {
     cat *_metafusion_cluster.unfiltered.cff \\
         | awk 'FNR <= 1' > header.txt
     cat *_metafusion_cluster.unfiltered.cff \\
-        | grep -iFwf $clinical_genes | awk '\$20 != "NA" && \$22 != "NA"' > tmp_clinicalgenes.txt
+        | grep -iFwf $clinical_genes | awk '\$20 != "NA" && \$22 != "NA"'  > tmp_clinicalgenes.txt || test \$? = 1
     cat header.txt tmp_clinicalgenes.txt > ${sample}_metafusion_cluster.unfiltered.clinical.cff
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/agfusion/batch/main.nf
+++ b/modules/local/agfusion/batch/main.nf
@@ -14,8 +14,7 @@ process AGFUSION_BATCH {
     path(pyensembl_cache)
 
     output:
-    tuple val(meta), path("${prefix}/**")                    , emit: fusions_annotated
-    tuple val(meta), path("${prefix}.fusion_transcripts.csv"), emit: fusion_transcripts_csv
+    tuple val(meta), path("${prefix}/**")                    , emit: fusions_annotated, optional: true
     tuple val(meta), path("${prefix}.fusion_transcripts.tsv"), emit: fusion_transcripts_tsv
     path "versions.yml"                                      , emit: versions
 
@@ -29,15 +28,19 @@ process AGFUSION_BATCH {
     export PYENSEMBL_CACHE_DIR=\$PWD/${pyensembl_cache}
 
     awk -F"\\t" 'NR == 1 && \$1 ~ /gene5_chr/ {next;}{print}' ${fusions} > ${fusions}.no_header
+    
+    if [ -s ${fusions}.no_header ]; then
+        agfusion batch \\
+            -f ${fusions}.no_header \\
+            -db ${agfusion_db} \\
+            -o ${prefix} \\
+            ${args}
 
-    agfusion batch \\
-        -f ${fusions}.no_header \\
-        -db ${agfusion_db} \\
-        -o ${prefix} \\
-        ${args}
-
-    awk -F"," 'NR != 1 && FNR == 1 {next;}{print}' ${prefix}/*/*.fusion_transcripts.csv > ${prefix}.fusion_transcripts.csv
-    cat ${prefix}.fusion_transcripts.csv | tr "," "\\t" > ${prefix}.fusion_transcripts.tsv
+        awk -F"," 'NR != 1 && FNR == 1 {next;}{print}' ${prefix}/*/*.fusion_transcripts.csv > ${prefix}.fusion_transcripts.csv
+        cat ${prefix}.fusion_transcripts.csv | tr "," "\\t" > ${prefix}.fusion_transcripts.tsv
+    else 
+        echo -e "3'_transcript\t5'_transcript\t5'_gene\t3'_gene\t5'_breakpoint\t3'_breakpoint\t5'_strand\t3'_strand\t5'_transcript_biotype\t3'_transcript_biotype" > ${prefix}.fusion_transcripts.tsv
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/agfusion/batch/main.nf
+++ b/modules/local/agfusion/batch/main.nf
@@ -28,7 +28,7 @@ process AGFUSION_BATCH {
     export PYENSEMBL_CACHE_DIR=\$PWD/${pyensembl_cache}
 
     awk -F"\\t" 'NR == 1 && \$1 ~ /gene5_chr/ {next;}{print}' ${fusions} > ${fusions}.no_header
-    
+
     if [ -s ${fusions}.no_header ]; then
         agfusion batch \\
             -f ${fusions}.no_header \\
@@ -38,7 +38,7 @@ process AGFUSION_BATCH {
 
         awk -F"," 'NR != 1 && FNR == 1 {next;}{print}' ${prefix}/*/*.fusion_transcripts.csv > ${prefix}.fusion_transcripts.csv
         cat ${prefix}.fusion_transcripts.csv | tr "," "\\t" > ${prefix}.fusion_transcripts.tsv
-    else 
+    else
         echo -e "3'_transcript\t5'_transcript\t5'_gene\t3'_gene\t5'_breakpoint\t3'_breakpoint\t5'_strand\t3'_strand\t5'_transcript_biotype\t3'_transcript_biotype" > ${prefix}.fusion_transcripts.tsv
     fi
 


### PR DESCRIPTION
<!--
# mskcc/forte pull request

Many thanks for contributing to mskcc/forte!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the develop branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/mskcc/forte/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] Removes any fusion with NA as one of the gene pairs from expanded clinical agfusion runs. When agfusion hits a fusion with NA as one of the genes, it will error out and fails. Closes #158 
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
